### PR TITLE
Update Signer to Support Body Variants & Sign all Headers

### DIFF
--- a/aws-sig-v4-test-suite/get-vanilla-query-order-key-case/get-vanilla-query-order-key-case.req
+++ b/aws-sig-v4-test-suite/get-vanilla-query-order-key-case/get-vanilla-query-order-key-case.req
@@ -1,3 +1,2 @@
 GET /?Param2=value2&Param1=value1 HTTP/1.1
 Host:example.amazonaws.com
-X-Amz-Date:20150830T123600Z

--- a/aws-sigv4/Cargo.toml
+++ b/aws-sigv4/Cargo.toml
@@ -21,6 +21,7 @@ serde_urlencoded = "0.7"
 bytes = "1"
 hex = "0.4"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+percent-encoding = "2.1.0"
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/aws-sigv4/src/lib.rs
+++ b/aws-sigv4/src/lib.rs
@@ -517,7 +517,6 @@ mod tests {
     fn test_double_url_encode() -> Result<(), Error> {
         let s = read!(req: "double-url-encode")?;
         let req = parse_request(s.as_bytes())?;
-        println!("{:?}", req);
         let date = DateTime::parse_aws("20210511T154045Z")?;
         let creq = CanonicalRequest::from(
             &req,
@@ -531,6 +530,20 @@ mod tests {
         let actual = format!("{}", creq);
         let expected = read!(creq: "double-url-encode")?;
         assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_tilde_in_uri() -> Result<(), Error> {
+        let req = http::Request::builder().uri("https://s3.us-east-1.amazonaws.com/my-bucket?list-type=2&prefix=~objprefix").body("").unwrap();
+        let date = DateTime::parse_aws("20210511T154045Z")?;
+        let creq = CanonicalRequest::from(
+            &req, SignableBody::Bytes(req.body().as_ref()),
+            &SigningSettings::default(),
+            date,
+            None
+        )?.0;
+        assert_eq!(creq.params, "list-type=2&prefix=~objprefix");
         Ok(())
     }
 

--- a/aws-sigv4/src/lib.rs
+++ b/aws-sigv4/src/lib.rs
@@ -535,7 +535,7 @@ mod tests {
 
     #[test]
     fn test_tilde_in_uri() -> Result<(), Error> {
-        let req = http::Request::builder().uri("https://s3.us-east-1.amazonaws.com/my-bucket?list-type=2&prefix=~objprefix&single&k=").body("").unwrap();
+        let req = http::Request::builder().uri("https://s3.us-east-1.amazonaws.com/my-bucket?list-type=2&prefix=~objprefix&single&k=&unreserved=-_.~").body("").unwrap();
         let date = DateTime::parse_aws("20210511T154045Z")?;
         let creq = CanonicalRequest::from(
             &req, SignableBody::Bytes(req.body().as_ref()),
@@ -543,7 +543,7 @@ mod tests {
             date,
             None
         )?.0;
-        assert_eq!(creq.params, "k=&list-type=2&prefix=~objprefix&single=");
+        assert_eq!(creq.params, "k=&list-type=2&prefix=~objprefix&single=&unreserved=-_.~");
         Ok(())
     }
 

--- a/aws-sigv4/src/lib.rs
+++ b/aws-sigv4/src/lib.rs
@@ -111,6 +111,8 @@ impl Default for SigningSettings {
     }
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum SignableBody<'a> {
     /// A body composed of a slice of bytes
     Bytes(&'a [u8]),
@@ -126,7 +128,7 @@ pub enum SignableBody<'a> {
     Precomputed(String),
 }
 
-/// req must NOT contain any of the following headers:
+/// req MUST NOT contain any of the following headers:
 /// - x-amz-date
 /// - x-amz-content-sha-256
 /// - x-amz-security-token

--- a/aws-sigv4/src/lib.rs
+++ b/aws-sigv4/src/lib.rs
@@ -147,7 +147,7 @@ pub fn sign_core<'a, B>(
     let mut content = extra_headers
         .x_amz_content_256
         .map(|content| (X_AMZ_CONTENT_SHA_256, content));
-    Ok(iter::once(("Authorization", authorization))
+    Ok(iter::once(("authorization", authorization))
         .chain(iter::once(date))
         .chain(iter::from_fn(move || {
             security_token.take().or_else(|| content.take())

--- a/aws-sigv4/src/lib.rs
+++ b/aws-sigv4/src/lib.rs
@@ -535,7 +535,7 @@ mod tests {
 
     #[test]
     fn test_tilde_in_uri() -> Result<(), Error> {
-        let req = http::Request::builder().uri("https://s3.us-east-1.amazonaws.com/my-bucket?list-type=2&prefix=~objprefix").body("").unwrap();
+        let req = http::Request::builder().uri("https://s3.us-east-1.amazonaws.com/my-bucket?list-type=2&prefix=~objprefix&single&k=").body("").unwrap();
         let date = DateTime::parse_aws("20210511T154045Z")?;
         let creq = CanonicalRequest::from(
             &req, SignableBody::Bytes(req.body().as_ref()),
@@ -543,7 +543,7 @@ mod tests {
             date,
             None
         )?.0;
-        assert_eq!(creq.params, "list-type=2&prefix=~objprefix");
+        assert_eq!(creq.params, "k=&list-type=2&prefix=~objprefix&single=");
         Ok(())
     }
 

--- a/aws-sigv4/src/sign.rs
+++ b/aws-sigv4/src/sign.rs
@@ -1,7 +1,7 @@
 use crate::types::DateExt;
 use chrono::{Date, Utc};
 use ring::{
-    digest::{self, Context, Digest, SHA256},
+    digest::{self, Digest},
     hmac::{self, Key, Tag},
 };
 

--- a/aws-sigv4/src/sign.rs
+++ b/aws-sigv4/src/sign.rs
@@ -12,14 +12,6 @@ pub fn encode(s: String) -> Vec<u8> {
 }
 
 /// HashedPayload = Lowercase(HexEncode(Hash(requestPayload)))
-pub fn encode_with_hex(s: String) -> String {
-    let digest: Digest = digest::digest(&digest::SHA256, s.as_bytes());
-    // no need to lower-case as in step six, as hex::encode
-    // already returns a lower-cased string.
-    hex::encode(digest)
-}
-
-/// HashedPayload = Lowercase(HexEncode(Hash(requestPayload)))
 pub fn encode_bytes_with_hex<B>(bytes: B) -> String
 where
     B: AsRef<[u8]>,
@@ -35,10 +27,6 @@ pub fn calculate_signature(signing_key: Tag, string_to_sign: &[u8]) -> String {
     let tag = hmac::sign(&s_key, string_to_sign);
 
     hex::encode(tag)
-}
-
-pub fn sha256_digest(data: &[u8]) -> String {
-    encode_bytes_with_hex(data)
 }
 
 // kSecret = your secret access key

--- a/aws-sigv4/src/sign.rs
+++ b/aws-sigv4/src/sign.rs
@@ -1,7 +1,7 @@
 use crate::types::DateExt;
 use chrono::{Date, Utc};
 use ring::{
-    digest::{self, Digest},
+    digest::{self, Context, Digest, SHA256},
     hmac::{self, Key, Tag},
 };
 
@@ -35,6 +35,10 @@ pub fn calculate_signature(signing_key: Tag, string_to_sign: &[u8]) -> String {
     let tag = hmac::sign(&s_key, string_to_sign);
 
     hex::encode(tag)
+}
+
+pub fn sha256_digest(data: &[u8]) -> String {
+    encode_bytes_with_hex(data)
 }
 
 // kSecret = your secret access key

--- a/aws-sigv4/src/types.rs
+++ b/aws-sigv4/src/types.rs
@@ -1,8 +1,6 @@
 use crate::{
-    header::HeaderValue,
-    sign::{encode_bytes_with_hex, sha256_digest},
-    Config, Error, SignableBody, SignedBodyHeaderType, SigningSettings, UriEncoding, DATE_FORMAT,
-    HMAC_256,
+    header::HeaderValue, sign::encode_bytes_with_hex, Error, SignableBody, SignedBodyHeaderType,
+    SigningSettings, UriEncoding, DATE_FORMAT, HMAC_256,
 };
 use chrono::{format::ParseError, Date, DateTime, NaiveDate, NaiveDateTime, Utc};
 use http::{header::HeaderName, HeaderMap, Method, Request};
@@ -10,7 +8,7 @@ use serde_urlencoded as qs;
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet},
-    convert::{AsRef, TryFrom},
+    convert::TryFrom,
     fmt,
 };
 
@@ -91,14 +89,11 @@ impl CanonicalRequest {
         let x_amz_date = HeaderName::from_static("x-amz-date");
         let date_str = date.fmt_aws();
         let date_header = HeaderValue::from_str(&date_str).expect("date is valid header value");
-        canonical_headers.insert(
-            x_amz_date,
-            date_header
-        );
+        canonical_headers.insert(x_amz_date, date_header);
         let mut out = AddedHeaders {
             x_amz_date: date_str,
             x_amz_content_256: None,
-            x_amz_security_token: None
+            x_amz_security_token: None,
         };
 
         if let Some(security_token) = security_token {
@@ -108,7 +103,7 @@ impl CanonicalRequest {
             );
             out.x_amz_security_token = Some(security_token.to_string());
         }
-        
+
         let payload_hash = match body {
             SignableBody::Bytes(data) => encode_bytes_with_hex(data),
             SignableBody::Precomputed(digest) => digest.clone(),

--- a/aws-sigv4/src/types.rs
+++ b/aws-sigv4/src/types.rs
@@ -82,10 +82,8 @@ impl CanonicalRequest {
             for (i, (k, v)) in params.into_iter().enumerate() {
                 let last = i == n - 1;
                 out.push_str(&percent_encoding::percent_encode(&k.as_bytes(), BASE_SET).to_string());
-                if v != "" {
-                    out.push('=');
-                    out.push_str(&percent_encoding::percent_encode(&v.as_bytes(), BASE_SET).to_string());
-                }
+                out.push('=');
+                out.push_str(&percent_encoding::percent_encode(&v.as_bytes(), BASE_SET).to_string());
                 if !last {
                     out.push('&');
                 }


### PR DESCRIPTION
2 signer updates:
- Include x-amz-date and x-amz-security-token in the signed headers (previously they were not added to the canonical request)
- Support a tri-state body: Bytes, UnsignedPayload, PresignedPayload
- Add some more tests